### PR TITLE
feat(chai-to-assert): support throwError and throwException

### DIFF
--- a/lib/bdd-api-to-node-assert.js
+++ b/lib/bdd-api-to-node-assert.js
@@ -36,7 +36,7 @@ var MATCHER_METHODS = [
   'string',
   'respondTo', 'respondsTo',
   'satisfy', 'satisfies',
-  'throw', 'throws', 'Throw'
+  'throw', 'throws', 'Throw', 'throwError', 'throwException',
 ];
 var FLAGS = [
   'deep',
@@ -476,6 +476,8 @@ module.exports = function bddApiToNodeAssert (file, api, options) {
       case 'throw':
       case 'throws':
       case 'Throw':
+      case 'throwException':
+      case 'throwError':
         var errorMatcher;
         if (path.value.arguments.length < 2) {
           errorMatcher = path.value.arguments;

--- a/test/bdd_api_test.js
+++ b/test/bdd_api_test.js
@@ -554,6 +554,22 @@ describe('.throw([errorLike], [errMsgMatcher])', function () {
     before: 'expect(func).to.not.throw(SomeError, /error message/)',
     after: 'assert.doesNotThrow(func, function(err) {\n  return err instanceof SomeError && /error message/.test(err.message);\n})'
   });
+  testTransform({
+    before: 'expect(func).to.throwError(SomeError)',
+    after: 'assert.throws(func, SomeError)'
+  });
+  testTransform({
+    before: 'expect(func).to.not.throwError(SomeError)',
+    after: 'assert.doesNotThrow(func, SomeError)'
+  });
+  testTransform({
+    before: 'expect(func).to.throwException(SomeError)',
+    after: 'assert.throws(func, SomeError)'
+  });
+  testTransform({
+    before: 'expect(func).to.not.throwException(SomeError)',
+    after: 'assert.doesNotThrow(func, SomeError)'
+  });
 });
 
 describe('.property(name, [value])', function () {


### PR DESCRIPTION
Compatible with expect.js